### PR TITLE
Fix Next.js 15 build error with dynamic route params

### DIFF
--- a/app/api/slack/[endpoint]/route.ts
+++ b/app/api/slack/[endpoint]/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { endpoint: string } }
+  { params }: { params: Promise<{ endpoint: string }> }
 ) {
-  const endpoint = params.endpoint;
+  const { endpoint } = await params;
   const body = await request.json();
   const { token, ...slackParams } = body;
 


### PR DESCRIPTION
- Update route handler to use async params (Next.js 15 breaking change)
- Change params type from { endpoint: string } to Promise<{ endpoint: string }>
- Await params before accessing endpoint property

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request parameter handling for Slack integration endpoints to prevent intermittent errors and timeouts during requests.
  * Improved robustness of incoming request processing, reducing chances of 500 errors and ensuring consistent responses.
  * Users should see more reliable Slack command and event processing with fewer failed attempts.
  * No changes to behavior or configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->